### PR TITLE
Sidekiq logging improvements, faster JSON serialization, customizability of log-level and default context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 cache: bundler
 rvm:
   - 2.4.6
-  - 2.5.5
-  - 2.6.3
-before_install: gem install bundler -v 2.0.1
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
+before_install: gem install bundler -v 2.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+### 0.9.3 (2020-09-20)
+
+[Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.2...v0.9.3)
+
+* Features & enhancements 
+    * Switching to [Oj](https://github.com/ohler55/oj) for fast JSON serialization
+    * Allow level to be formatted (so it can be logged as a number too)
+    
+        if you want to use Ougai-like numbers you can do something like this: 
+        ```ruby
+        config.ezlog.layout_options = { level_formatter: ->(level_number) { (level_number + 2) * 10 } } 
+        
+        Rails.logger.error('Boom!')
+        #=> {"logger":"Application","timestamp":"2020-09-20T19:29:03+02:00","level":50,"hostname":"BUD010256.local","pid":19872,"message":"Boom!"}
+        ``` 
+    * initial context (a context which will be added to every single line of log) can be configured via `config.ezlog.layout_options` and it defaults to `{environment: ::Rails.env}`
+    
 ### 0.9.2 (2020-09-19)
 
 [Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.1...v0.9.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.9.2 (2020-09-19)
+
+[Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.1...v0.9.2)
+
+* Features & enhancements 
+  * Improvements of the [Sidekiq](https://github.com/mperham/sidekiq) integration
+    * supports additional job information: batch id, tags and thread id (bid, tags, tid)
+    * support logging "death" events (setting up a death_handler) 
+
 ### 0.9.1 (2020-05-10)
 
 [Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.0...v0.9.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 0.9.4 (2020-09-26)
+
+[Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.3...v0.9.4)
+
+* Features & enhancements
+  * added Ruby 2.7 to the list of version CI will test the code with
+  * remove dot-files and Rakefile from the gem
+* Fix
+  * stop using `Hash#merge` with multiple arguments as it's only supported from Ruby 2.6
+
 ### 0.9.3 (2020-09-20)
 
 [Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.2...v0.9.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.9.5 (2020-10-1)
+
+[Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.4...v0.9.5)
+
+* Fix
+  * fixing an issue with the Sidekiq job's log context generation:
+    using a namespaced Sidekiq worker (`SomeModule::SomeWorker`) cause the log context generations to fail with: `NameError: wrong constant name SomeModule::SomeWorker`
+
 ### 0.9.4 (2020-09-26)
 
 [Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.3...v0.9.4)

--- a/ezlog.gemspec
+++ b/ezlog.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "logging", "~> 2.0"
+  spec.add_dependency "oj", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"

--- a/ezlog.gemspec
+++ b/ezlog.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^((test|spec|features)/|Rakefile|\.)}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/ezlog/logging_layout.rb
+++ b/lib/ezlog/logging_layout.rb
@@ -3,8 +3,9 @@ require 'json'
 
 module Ezlog
   class LoggingLayout < ::Logging::Layout
-    def initialize(context = {})
+    def initialize(context = {}, options = {})
       @initial_context = context
+      @level_formatter = options.fetch(:level_formatter, ->(numeric_level) { ::Logging::LNAMES[numeric_level] })
     end
 
     def format(event)
@@ -20,8 +21,8 @@ module Ezlog
     def basic_information_for(event)
       {
         'logger' => event.logger,
-        'timestamp' => event.time.iso8601,
-        'level' => ::Logging::LNAMES[event.level],
+        'timestamp' => event.time.iso8601(3),
+        'level' => @level_formatter.call(event.level),
         'hostname' => Socket.gethostname,
         'pid' => Process.pid
       }
@@ -46,17 +47,17 @@ module Ezlog
       when Hash
         obj
       else
-        {message: obj}
+        { 'message' => obj }
       end
     end
 
     def exception_message_by(exception)
       {
-        message: exception.message,
-        error: {
-          class: exception.class.name,
-          message: exception.message,
-          backtrace: exception.backtrace&.first(20)
+        'message' => exception.message,
+        'error' => {
+          'class' => exception.class.name,
+          'message' => exception.message,
+          'backtrace' => exception.backtrace&.first(20)
         }
       }
     end

--- a/lib/ezlog/logging_layout.rb
+++ b/lib/ezlog/logging_layout.rb
@@ -1,5 +1,5 @@
 require 'time'
-require 'json'
+require 'oj'
 
 module Ezlog
   class LoggingLayout < ::Logging::Layout
@@ -13,7 +13,7 @@ module Ezlog
       add_initial_context_to log_entry
       add_logging_context_to log_entry
       add_event_information_to log_entry, event
-      ::JSON.dump(log_entry) + "\n"
+      ::Oj.dump(log_entry, mode: :json) + "\n"
     end
 
     private

--- a/lib/ezlog/railtie.rb
+++ b/lib/ezlog/railtie.rb
@@ -5,13 +5,17 @@ module Ezlog
     config.ezlog.log_only_whitelisted_params = false
     config.ezlog.whitelisted_params = [:controller, :action]
     config.ezlog.exclude_paths = []
+    config.ezlog.initial_context = { environment: ::Rails.env }
+    config.ezlog.layout_options = {}
 
     initializer "ezlog.initialize" do
       require "ezlog/rails/extensions"
     end
 
     initializer 'ezlog.configure_logging' do |app|
-      ::Logging.logger.root.appenders = ::Logging.appenders.stdout 'stdout', layout: Ezlog::LoggingLayout.new(environment: ::Rails.env)
+      ::Logging.logger.root.appenders =
+        ::Logging.appenders.stdout 'stdout', layout: Ezlog::LoggingLayout.new(app.config.ezlog.initial_context,
+                                                                              app.config.ezlog.layout_options)
       ::Logging.logger.root.level = app.config.log_level
     end
 

--- a/lib/ezlog/railtie.rb
+++ b/lib/ezlog/railtie.rb
@@ -67,6 +67,7 @@ module Ezlog
         config.options[:job_logger] = Ezlog::Sidekiq::JobLogger
         config.error_handlers << Ezlog::Sidekiq::ErrorLogger.new
         config.error_handlers.delete_if { |handler| handler.is_a? ::Sidekiq::ExceptionHandler::Logger }
+        config.death_handlers << Ezlog::Sidekiq::DeathLogger.new
       end
     end
 

--- a/lib/ezlog/sidekiq.rb
+++ b/lib/ezlog/sidekiq.rb
@@ -1,5 +1,6 @@
 module Ezlog
   module Sidekiq
+    autoload :DeathLogger, 'ezlog/sidekiq/death_logger'
     autoload :ErrorLogger, 'ezlog/sidekiq/error_logger'
     autoload :JobContext, 'ezlog/sidekiq/job_context'
     autoload :JobLogger, 'ezlog/sidekiq/job_logger'

--- a/lib/ezlog/sidekiq/death_logger.rb
+++ b/lib/ezlog/sidekiq/death_logger.rb
@@ -1,0 +1,15 @@
+require 'sidekiq'
+
+module Ezlog
+  module Sidekiq
+    class DeathLogger
+      include LogContextHelper
+
+      def call(job, error)
+        within_log_context(JobContext.from_job_hash(job)) do
+          ::Sidekiq.logger.error error
+        end
+      end
+    end
+  end
+end

--- a/lib/ezlog/sidekiq/job_context.rb
+++ b/lib/ezlog/sidekiq/job_context.rb
@@ -37,7 +37,7 @@ module Ezlog
         end
 
         def method_parameters_of(job)
-          Kernel.const_get(job_class(job).to_sym).instance_method(:perform).parameters
+          Kernel.const_get(job_class(job)).instance_method(:perform).parameters
         end
 
         def job_class(job)

--- a/lib/ezlog/sidekiq/job_context.rb
+++ b/lib/ezlog/sidekiq/job_context.rb
@@ -4,13 +4,18 @@ module Ezlog
       class << self
         def from_job_hash(job_hash)
           return {} if job_hash.nil?
-          basic_info_from(job_hash).merge named_arguments_from(job_hash)
+          thread_info.merge basic_info_from(job_hash), named_arguments_from(job_hash)
         end
 
         private
 
+        def thread_info
+          { tid: Thread.current['sidekiq_tid'] || (Thread.current.object_id ^ ::Process.pid).to_s(36) }
+        end
+
+
         def basic_info_from(job)
-          {
+          h = {
             jid: job['jid'],
             queue: job['queue'],
             worker: job_class(job),
@@ -18,6 +23,9 @@ module Ezlog
             enqueued_at: job['enqueued_at'],
             run_count: (job['retry_count'] || -1) + 2
           }
+          h[:bid] = job['bid'] if job['bid']
+          h[:tags] = job['tags'] if job['tags']
+          h
         end
 
         def named_arguments_from(job)

--- a/lib/ezlog/sidekiq/job_context.rb
+++ b/lib/ezlog/sidekiq/job_context.rb
@@ -4,7 +4,7 @@ module Ezlog
       class << self
         def from_job_hash(job_hash)
           return {} if job_hash.nil?
-          thread_info.merge basic_info_from(job_hash), named_arguments_from(job_hash)
+          thread_info.merge(basic_info_from(job_hash)).merge(named_arguments_from(job_hash))
         end
 
         private

--- a/lib/ezlog/version.rb
+++ b/lib/ezlog/version.rb
@@ -1,3 +1,3 @@
 module Ezlog
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end

--- a/lib/ezlog/version.rb
+++ b/lib/ezlog/version.rb
@@ -1,3 +1,3 @@
 module Ezlog
-  VERSION = '0.9.4'
+  VERSION = '0.9.5'
 end

--- a/lib/ezlog/version.rb
+++ b/lib/ezlog/version.rb
@@ -1,3 +1,3 @@
 module Ezlog
-  VERSION = '0.9.3'
+  VERSION = '0.9.4'
 end

--- a/lib/ezlog/version.rb
+++ b/lib/ezlog/version.rb
@@ -1,3 +1,3 @@
 module Ezlog
-  VERSION = '0.9.2'
+  VERSION = '0.9.3'
 end

--- a/spec/ezlog/sidekiq/death_logger_spec.rb
+++ b/spec/ezlog/sidekiq/death_logger_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Ezlog::Sidekiq::DeathLogger do
+  include_context 'Sidekiq'
+
+  let(:logger) { Ezlog::Sidekiq::DeathLogger.new }
+
+  describe '#call' do
+    subject(:call) { logger.call job, error }
+
+    let(:error) { StandardError.new 'error message' }
+    let(:job) { sidekiq_job_hash(jid: 'job ID') }
+
+    it 'logs the error in a single message at ERROR level' do
+      expect { call }.to log(message: 'error message').at_level(:error)
+    end
+
+    it 'logs the job context' do
+      expect { call }.to log jid: 'job ID'
+    end
+  end
+end

--- a/spec/ezlog/sidekiq/job_context_spec.rb
+++ b/spec/ezlog/sidekiq/job_context_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe Ezlog::Sidekiq::JobContext do
       end
     end
 
+    context 'when the job is in a module' do
+      before { job_hash.merge! 'class' => 'TestWorkers::TestWorker', 'args' => [667, 1024] }
+
+      it 'contains the wrapped job class' do
+        expect(job_message).to include worker: 'TestWorkers::TestWorker'
+      end
+
+      it 'contains the arguments' do
+        expect(job_message).to include export_id: 667,
+                                       max_size: 1024
+      end
+    end
+
     context 'when the job is part of a batch' do
       before { job_hash['bid'] = 'aBatchId' }
 

--- a/spec/ezlog/sidekiq/job_context_spec.rb
+++ b/spec/ezlog/sidekiq/job_context_spec.rb
@@ -44,6 +44,38 @@ RSpec.describe Ezlog::Sidekiq::JobContext do
       end
     end
 
+    context 'when the job is part of a batch' do
+      before { job_hash['bid'] = 'aBatchId' }
+
+      it 'contains the batch id' do
+        expect(job_message).to include bid: 'aBatchId'
+      end
+    end
+
+    context 'when the job has tags' do
+      before { job_hash['tags'] = %w[a-tag b-tag] }
+
+      it 'contains the batch id' do
+        expect(job_message).to include tags: %w[a-tag b-tag]
+      end
+    end
+
+    context "when Sidekiq's thread id of is set on the current thread" do
+      before { Thread.current['sidekiq_tid'] = '[the thread id]' }
+
+      it 'contains the thread id of the worker' do
+        expect(job_message).to include tid: '[the thread id]'
+      end
+    end
+
+    context "when Sidekiq's thread id is not set on the current thread" do
+      before { Thread.current['sidekiq_tid'] = nil }
+
+      it 'calculates a thread id' do
+        expect(job_message).to include tid: (Thread.current.object_id ^ ::Process.pid).to_s(36)
+      end
+    end
+
     context 'when the job hash is empty' do
       let(:job_hash) { nil }
 

--- a/spec/support/shared_contexts/sidekiq.rb
+++ b/spec/support/shared_contexts/sidekiq.rb
@@ -14,6 +14,12 @@ RSpec.shared_context 'Sidekiq' do
     def perform(customer_id, name) end
   end
 
+  module TestWorkers
+    class TestWorker
+      def perform(export_id, max_size) end
+    end
+  end
+
   def sidekiq_job_hash(jid: 'job id',
                        bid: nil,
                        tags: nil,

--- a/spec/support/shared_contexts/sidekiq.rb
+++ b/spec/support/shared_contexts/sidekiq.rb
@@ -11,11 +11,12 @@ RSpec.shared_context 'Sidekiq' do
   end
 
   class TestWorker
-    def perform(customer_id, name)
-    end
+    def perform(customer_id, name) end
   end
 
   def sidekiq_job_hash(jid: 'job id',
+                       bid: nil,
+                       tags: nil,
                        queue: 'job queue',
                        worker: 'TestWorker',
                        args: [],
@@ -23,11 +24,13 @@ RSpec.shared_context 'Sidekiq' do
                        enqueued_at: Time.now)
     {
       'jid' => jid,
+      'bid' => bid,
+      'tags' => tags,
       'queue' => queue,
       'class' => worker,
       'args' => args,
       'created_at' => created_at,
       'enqueued_at' => enqueued_at
-    }
+    }.compact
   end
 end


### PR DESCRIPTION
#### Sikdekiq
- death logger
- additional contextual info on jobs: thread id, batch id, tags

#### JSON serialization
- using Oj for much faster serialization

#### Customization
- allow the format id  'level' to be formatted using a Proc (so if you want to use number it's possible now)
- initial context can be set as well (defaults to the previously used value)

no breaking changes introduced, for more details see the changelog