### PR TITLE
Fix "uninitialized constant ActionView::LogSubscriber" error with Ruby 3.1 and Rails 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.10.1 (2022-01-22)
+
+[Full Changelog](https://github.com/emartech/ezlog/compare/v0.10.0...v0.10.1)
+
+* Fix
+  * Fixed a bug where `ActionView::LogSubscriber` was potentially not (eager)loaded by the time we tried to detach it.
+    With this fix Rails 6.1 running on Ruby 3 should be fully supported.
+
 ### 0.10.0 (2021-07-01)
 
 [Full Changelog](https://github.com/emartech/ezlog/compare/v0.9.6...v0.10.0)

--- a/lib/ezlog/railtie.rb
+++ b/lib/ezlog/railtie.rb
@@ -42,7 +42,10 @@ module Ezlog
       case ::Rails::VERSION::MAJOR
       when 6
         ::ActionController::LogSubscriber.detach_from :action_controller
-        ::ActionView::LogSubscriber.detach_from :action_view
+        if defined? ::ActionView
+          require 'action_view/log_subscriber' unless defined? ::ActionView::LogSubscriber
+          ::ActionView::LogSubscriber.detach_from :action_view
+        end
         if defined? ::ActiveRecord
           ::ActiveRecord::LogSubscriber.detach_from :active_record
           Ezlog::Rails::LogSubscriber.attach Ezlog::Rails::ActiveRecord::LogSubscriber, :active_record

--- a/lib/ezlog/version.rb
+++ b/lib/ezlog/version.rb
@@ -1,3 +1,3 @@
 module Ezlog
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end


### PR DESCRIPTION
We just upgraded one of our projects to Ruby 3.1 from 2.7 (also had to upgrade Rails to 6.1 from 6.0 along with it) and found that the build is breaking with this error message:

```
Failure/Error: require File.expand_path('../config/environment', __dir__)

NameError:
  uninitialized constant ActionView::LogSubscriber

          ::ActionView::LogSubscriber.detach_from :action_view
                      ^^^^^^^^^^^^^^^
# ./config/environment.rb:5:in `<top (required)>'
# ./spec/rails_helper.rb:4:in `require'
# ./spec/rails_helper.rb:4:in `<top (required)>'
```

Looking at the original error, we got the following:

```
$HOME/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/ezlog-0.10.0/lib/ezlog/railtie.rb:45:in `block in <class:Railtie>': uninitialized constant ActionView::LogSubscriber

        ::ActionView::LogSubscriber.detach_from :action_view
                    ^^^^^^^^^^^^^^^ (NameError)
```

This was confusing because the project is an API-only project with ActionView turned off (not required). Unfortunately, looking at the code we learned that:
1. You can turn off ActionView in your `application.rb` but ActionPack will require it nonetheless, so there's no disabling it (at the moment).
2. The `ActionView::LogSubscriber` is eager loaded and not defined any more during application startup but is rather loaded on demand with the first request.

Because of the above, if we want to detach the log subscriber right after application startup, we have to make sure that it's loaded first (it would be loaded with the first request anyway).