### PR TITLE
Sidekiq 6.5 compatibility

### DIFF
--- a/lib/ezlog/railtie.rb
+++ b/lib/ezlog/railtie.rb
@@ -73,7 +73,9 @@ module Ezlog
       ::Sidekiq.configure_server do |config|
         config.options[:job_logger] = Ezlog::Sidekiq::JobLogger
         config.error_handlers << Ezlog::Sidekiq::ErrorLogger.new
-        config.error_handlers.delete_if { |handler| handler.is_a? ::Sidekiq::ExceptionHandler::Logger }
+        if defined?(::Sidekiq::ExceptionHandler) && defined?(::Sidekiq::ExceptionHandler::Logger)
+          config.error_handlers.delete_if { |handler| handler.is_a? ::Sidekiq::ExceptionHandler::Logger }
+        end
         config.death_handlers << Ezlog::Sidekiq::DeathLogger.new
       end
     end


### PR DESCRIPTION
Fixes an issue with: 

```

Unhandled error
NameError: uninitialized constant Sidekiq::ExceptionHandler
       config.error_handlers.delete_if { |handler| handler.is_a? ::Sidekiq::ExceptionHandler::Logger }
                                                                          ^^^^^^^^^^^^^^^^^^
Location
config/environment.rb:7 - <top (required)>
```